### PR TITLE
Remove using namespace

### DIFF
--- a/s2sbuild.cpp
+++ b/s2sbuild.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[]){
       }
       wordList1.push_back(line.substr(0, p));
       wordList2.push_back(line.substr(p+1));
-      wordListPair.push_back(make_pair(line.substr(0, p), line.substr(p+1)));
+      wordListPair.push_back(std::make_pair(line.substr(0, p), line.substr(p+1)));
       lineno++;
     }
   }

--- a/s2sbuild.cpp
+++ b/s2sbuild.cpp
@@ -17,9 +17,10 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
 #include <fstream>
+#include <string>
 #include <vector>
+
 #include "tx.hpp"
 
 int createIndex(std::vector<std::string>& wordList, const std::string& indexName){
@@ -87,7 +88,6 @@ int main(int argc, char* argv[]){
     return -1;
   }
 
-  
   std::vector< std::vector<tx_tool::uint> > IDmap(wordListPair.size());
   for (size_t i = 0; i < wordListPair.size(); i++){
     size_t retLen1 = 0;

--- a/s2ssearch.cpp
+++ b/s2ssearch.cpp
@@ -17,37 +17,38 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
 #include <fstream>
+#include <string>
 #include <vector>
+
 #include "tx.hpp"
 
 int main(int argc, char* argv[]) {
   if (argc != 2) {
-    fprintf(stderr,"%s index\n",argv[0]);
+    fprintf(stderr, "%s index\n", argv[0]);
     return -1;
   }
 
   std::string indexName(argv[1]);
   tx_tool::tx t1;
-  if (t1.read((indexName+".1").c_str()) == -1) {
+  if (t1.read((indexName + ".1").c_str()) == -1) {
     fprintf(stderr, "%s", t1.getErrorLog().c_str());
-    fprintf(stderr,"cannot read index %s\n", (indexName+".1").c_str());
+    fprintf(stderr, "cannot read index %s\n", (indexName + ".1").c_str());
     return -1;
   }
-  fprintf(stderr,"%s", t1.getResultLog().c_str());
+  fprintf(stderr, "%s", t1.getResultLog().c_str());
 
   tx_tool::tx t2;
-  if (t2.read((indexName+".2").c_str()) == -1) {
+  if (t2.read((indexName + ".2").c_str()) == -1) {
     fprintf(stderr, "%s", t2.getErrorLog().c_str());
-    fprintf(stderr,"cannot read index %s\n", (indexName+".2").c_str());
+    fprintf(stderr, "cannot read index %s\n", (indexName + ".2").c_str());
     return -1;
   }
-  fprintf(stderr,"%s", t2.getResultLog().c_str());
+  fprintf(stderr, "%s", t2.getResultLog().c_str());
 
   std::vector<std::vector<tx_tool::uint> > IDmap;
   {
-    FILE* infp = fopen((indexName+".12").c_str(), "rb");
+    FILE* infp = fopen((indexName + ".12").c_str(), "rb");
     if (infp == NULL) {
       fprintf(stderr, "cannot open %s\n", (indexName + ".12").c_str());
       return -1;
@@ -77,16 +78,16 @@ int main(int argc, char* argv[]) {
   std::string query;
   for (;;) {
     putchar('>');
-    getline(std::cin,query);
+    getline(std::cin, query);
     if (query.size() == 0) break;
 
     // commonPrefixSearch
     for (size_t i = 0; i < query.size(); i++) {
       std::vector<std::string> ret;
       std::vector<tx_tool::uint> retID;
-      const tx_tool::uint retNum = t1.commonPrefixSearch(query.c_str()+i,query.size()-i, ret, retID, 10);
+      const tx_tool::uint retNum = t1.commonPrefixSearch(query.c_str() + i, query.size() - i, ret, retID, 10);
       for (tx_tool::uint i = 0; i < retNum; i++) {
-        printf("%s\t",ret[i].c_str());
+        printf("%s\t", ret[i].c_str());
         for (size_t j = 0; j < IDmap[retID[i]].size(); j++) {
           std::string ret;
           size_t retLen = t2.reverseLookup(IDmap[retID[i]][j], ret);
@@ -96,7 +97,6 @@ int main(int argc, char* argv[]) {
         printf("\n");
       }
     }
-
   }
   return 0;
 }

--- a/s2ssearch.cpp
+++ b/s2ssearch.cpp
@@ -22,15 +22,13 @@
 #include <vector>
 #include "tx.hpp"
 
-using namespace std;
-
 int main(int argc, char* argv[]){
   if (argc != 2){
     fprintf(stderr,"%s index\n",argv[0]);
     return -1;
   }
 
-  string indexName(argv[1]);
+  std::string indexName(argv[1]);
   tx_tool::tx t1;
   if (t1.read((indexName+".1").c_str()) == -1){
     fprintf(stderr, "%s", t1.getErrorLog().c_str());
@@ -76,21 +74,21 @@ int main(int argc, char* argv[]){
     }
   }
 
-  string query;
+  std::string query;
   for (;;){
     putchar('>');
-    getline(cin,query);
+    getline(std::cin,query);
     if (query.size() == 0) break;
 		
     // commonPrefixSearch
     for (size_t i = 0; i < query.size(); i++){
-      vector<string> ret;
-      vector<tx_tool::uint> retID;
+      std::vector<std::string> ret;
+      std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t1.commonPrefixSearch(query.c_str()+i,query.size()-i, ret, retID, 10);
       for (tx_tool::uint i = 0; i < retNum; i++){
 	printf("%s\t",ret[i].c_str());
 	for (size_t j = 0; j < IDmap[retID[i]].size(); j++){
-	  string ret;
+	  std::string ret;
 	  size_t retLen = t2.reverseLookup(IDmap[retID[i]][j], ret);
 	  if (retLen == 0) continue;
 	  printf("%s ", ret.c_str());

--- a/s2ssearch.cpp
+++ b/s2ssearch.cpp
@@ -1,10 +1,10 @@
-/* 
+/*
  *  Copyright (c) 2007-2010 Daisuke Okanohara
- * 
+ *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
- * 
+ *
  *   1. Redistributions of source code must retain the above Copyright
  *      notice, this list of conditions and the following disclaimer.
  *
@@ -22,15 +22,15 @@
 #include <vector>
 #include "tx.hpp"
 
-int main(int argc, char* argv[]){
-  if (argc != 2){
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
     fprintf(stderr,"%s index\n",argv[0]);
     return -1;
   }
 
   std::string indexName(argv[1]);
   tx_tool::tx t1;
-  if (t1.read((indexName+".1").c_str()) == -1){
+  if (t1.read((indexName+".1").c_str()) == -1) {
     fprintf(stderr, "%s", t1.getErrorLog().c_str());
     fprintf(stderr,"cannot read index %s\n", (indexName+".1").c_str());
     return -1;
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]){
   fprintf(stderr,"%s", t1.getResultLog().c_str());
 
   tx_tool::tx t2;
-  if (t2.read((indexName+".2").c_str()) == -1){
+  if (t2.read((indexName+".2").c_str()) == -1) {
     fprintf(stderr, "%s", t2.getErrorLog().c_str());
     fprintf(stderr,"cannot read index %s\n", (indexName+".2").c_str());
     return -1;
@@ -48,52 +48,52 @@ int main(int argc, char* argv[]){
   std::vector<std::vector<tx_tool::uint> > IDmap;
   {
     FILE* infp = fopen((indexName+".12").c_str(), "rb");
-    if (infp == NULL){
+    if (infp == NULL) {
       fprintf(stderr, "cannot open %s\n", (indexName + ".12").c_str());
       return -1;
     }
     const size_t keyNum1 = t1.getKeyNum();
-    for (size_t i = 0; i < keyNum1; i++){
+    for (size_t i = 0; i < keyNum1; i++) {
       tx_tool::uint num = 0;
-      if (fread(&num, sizeof(tx_tool::uint), 1, infp) != 1){
-	fprintf(stderr, "read error\n");
-	fclose(infp);
-	return -1;
+      if (fread(&num, sizeof(tx_tool::uint), 1, infp) != 1) {
+        fprintf(stderr, "read error\n");
+        fclose(infp);
+        return -1;
       }
       std::vector<tx_tool::uint> vals;
-      for (tx_tool::uint j = 0; j < num; j++){
-	tx_tool::uint val = 0;
-	if (fread(&val, sizeof(tx_tool::uint), 1, infp) != 1){
-	  fprintf(stderr, "read error\n");
-	  fclose(infp);
-	  return -1;
-	}
-	vals.push_back(val);
+      for (tx_tool::uint j = 0; j < num; j++) {
+        tx_tool::uint val = 0;
+        if (fread(&val, sizeof(tx_tool::uint), 1, infp) != 1) {
+          fprintf(stderr, "read error\n");
+          fclose(infp);
+          return -1;
+        }
+        vals.push_back(val);
       }
       IDmap.push_back(vals);
     }
   }
 
   std::string query;
-  for (;;){
+  for (;;) {
     putchar('>');
     getline(std::cin,query);
     if (query.size() == 0) break;
-		
+
     // commonPrefixSearch
-    for (size_t i = 0; i < query.size(); i++){
+    for (size_t i = 0; i < query.size(); i++) {
       std::vector<std::string> ret;
       std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t1.commonPrefixSearch(query.c_str()+i,query.size()-i, ret, retID, 10);
-      for (tx_tool::uint i = 0; i < retNum; i++){
-	printf("%s\t",ret[i].c_str());
-	for (size_t j = 0; j < IDmap[retID[i]].size(); j++){
-	  std::string ret;
-	  size_t retLen = t2.reverseLookup(IDmap[retID[i]][j], ret);
-	  if (retLen == 0) continue;
-	  printf("%s ", ret.c_str());
-	}
-	printf("\n");
+      for (tx_tool::uint i = 0; i < retNum; i++) {
+        printf("%s\t",ret[i].c_str());
+        for (size_t j = 0; j < IDmap[retID[i]].size(); j++) {
+          std::string ret;
+          size_t retLen = t2.reverseLookup(IDmap[retID[i]][j], ret);
+          if (retLen == 0) continue;
+          printf("%s ", ret.c_str());
+        }
+        printf("\n");
       }
     }
 

--- a/ssv.cpp
+++ b/ssv.cpp
@@ -1,10 +1,10 @@
-/* 
+/*
  *  Copyright (c) 2007-2010 Daisuke Okanohara
- * 
+ *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
- * 
+ *
  *   1. Redistributions of source code must retain the above Copyright
  *      notice, this list of conditions and the following disclaimer.
  *
@@ -19,356 +19,356 @@
 
 #include "ssv.hpp"
 
-namespace tx_tool{
+namespace tx_tool {
 
-  ssv::ssv(const uint _size):
-    B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false){
-    if (resize(_size) == -1) return;
-  }
-
-  ssv::ssv(std::vector<bool>& bv):
-    B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false){
-    if (resize((uint)bv.size()) == -1) return;
-    for (uint i = 0; i < (uint)bv.size(); i++){
-      setBit(i,bv[i]);
-    }
-  }
-
-  int ssv::resize(const uint _size){
-    free();
-    size = _size;
-    blockSize = size/SSV_BLOCK + 1;
-    isBuild = false;
-    B = new uint [blockSize];
-    if (B == NULL){
-      return -1;
-    }
-    memset(B,0,sizeof(uint)*blockSize);
-
-    LBlockSize = size / SSV_LBLOCK + 1;
-    MBlockSize = size / SSV_MBLOCK + 1;
-
-    levelL = new uint [LBlockSize];
-    levelM = new uchar [MBlockSize];
-    return 0;
-  }
-
-  void ssv::free(){
-    if (!no_delete){
-      if (B){
-	delete[] B; 
-	B=NULL;
-      }
-    }
-    if (levelL){
-      delete[] levelL; 
-      levelL=NULL;
-    }
-    if (levelM){
-      delete[] levelM;
-      levelM=NULL;
-    }
-  }
-
-  ssv::~ssv(){
-    free();
-  }
-
-  uint ssv::getBits(const uint pos, uint width) const{
-    assert(width <=32);
-    assert(pos+width <= size);
-    if (width == 0) return 0;
-
-    //---: block version
-    const uint endPos = pos+width-1;
-    const uint blockPos_1 = pos / SSV_BLOCK;
-    const uint blockPos_2 = endPos / SSV_BLOCK;
-    const uint offset_1   = pos % SSV_BLOCK;
-
-    if (blockPos_1 == blockPos_2){
-      if (width == 32){
-	return B[blockPos_1]; //avoid 1U << 32
-      }
-      else {
-	return (B[blockPos_1] >> offset_1) & ((1U << width) - 1);
-      }
-    }
-    else {
-      const uint offset_2   = endPos % SSV_BLOCK;
-      return  (B[blockPos_1] >> offset_1) + ((B[blockPos_2] & ((1U << (offset_2+1U))-1U)) << (32U-offset_1));
-    }		
-  }
-
-  void ssv::setBits(const uint pos, const uint width, const uint x){
-    assert(width <= 32);
-    assert(pos+width <= size);
-    if (width == 0) return;
-
-    //---: block version ----
-    const uint endPos     = pos+width-1;
-    const uint blockPos_1 = pos / SSV_BLOCK;
-    const uint blockPos_2 = endPos / SSV_BLOCK;
-    const uint offset_1   = pos % SSV_BLOCK;
-
-    if (blockPos_1 == blockPos_2){
-      if (width == 32){
-	B[blockPos_1] = x;
-      }
-      else {
-	B[blockPos_1] &= ~(((1U << width)-1) << offset_1); // |1111110000000111111|
-	B[blockPos_1] |= (x << offset_1);                  //        xxxxxxx
-      }
-    }
-    else {
-      const uint offset_2 = endPos % SSV_BLOCK;
-      B[blockPos_1] &= ((1U << offset_1)-1U);		
-      B[blockPos_1] |= (x << offset_1);
-      B[blockPos_2] &= ~((1U << (offset_2+1U))-1U);
-      B[blockPos_2] |= (x >> (32-offset_1));
-    }
-  }
-
-
-  uint ssv::rank(uint pos, const uint bit) const{
-    pos++;
-    if (bit == 0) return pos-_rank1(pos);
-    else		  return _rank1(pos);
-  }
-
-  uint ssv::select(const uint pos, const uint bit) const{
-    if (bit) return _select1(pos);
-    else     return _select0(pos);
-  }
-
-  void ssv::setBit(uint pos, uint x){
-    if (!x) B[pos / SSV_BLOCK] &= (~(1U << (pos % SSV_BLOCK)));
-    else    B[pos / SSV_BLOCK] |=   (1U << (pos % SSV_BLOCK));
-  }
-
-  uint ssv::getAllocate() const{
-    uint sum = size;
-    if (isBuild){
-      sum += LBlockSize * 32 + MBlockSize * 8;
-    }
-    return sum;
-  }
-
-  void ssv::build(){
-    oneNum = rankBuild(size);
-    isBuild = true;
-  }
-
-  uint ssv::rankBuild(const uint t_size){
-    uint sum = 0;
-    for (uint il = 0; il <= t_size ;il += SSV_LBLOCK){
-      levelL[il/SSV_LBLOCK] = sum;
-      for (uint im = 0; im < SSV_LBLOCK && il+im <= t_size; im += SSV_MBLOCK){
-	levelM[(il+im)/SSV_MBLOCK] = sum - levelL[il/SSV_LBLOCK];
-	for (uint is = 0; is < SSV_MBLOCK && (il+im+is) <= t_size; is += SSV_BLOCK){
-	  sum += popCount(B[(il+im+is)/SSV_BLOCK]);
-	}
-      }
-    }
-    return sum;
-  }
-
-
-  int ssv::write(FILE* outfp){
-    if (fwrite(&size,sizeof(uint),1,outfp) != 1){
-      return -1;
-    }
-    if (fwrite(B,sizeof(uint),blockSize,outfp) != blockSize){
-      return -1;
-    }
-    if (fwrite(levelL,sizeof(uint),LBlockSize,outfp) != LBlockSize){
-      return -1;
-    }
-    if (fwrite(levelM,sizeof(uchar),MBlockSize,outfp) != MBlockSize){
-      return -1;
-    }
-    return 0;
-  }
-
-  int ssv::read(FILE* infp){
-    if (fread(&size,sizeof(uint),1,infp) != 1){
-      return -1;
-    }
-    if (resize(size) == -1){
-      return -1;
-    }
-
-    if (fread(B,sizeof(uint),blockSize,infp) != blockSize){
-      return -1;
-    }
-    isBuild = true;
-
-    if (fread(levelL,sizeof(uint),LBlockSize,infp) != LBlockSize){
-      return -1; 
-    }
-    if (fread(levelM,sizeof(uchar),MBlockSize,infp) != MBlockSize){
-      return -1;
-    }
-    return 0;
-  }
-
-  size_t ssv::set_array(void* ptr){
-    size = *(uint*)(ptr);
-
-    blockSize = size/SSV_BLOCK + 1;
-    isBuild = false;
-    LBlockSize = size / SSV_LBLOCK + 1;
-    MBlockSize = size / SSV_MBLOCK + 1;
-  
-    B = ((uint*)ptr + 1);
-    levelL = ((uint*)ptr + 1 + blockSize);
-    levelM = ((uchar*)ptr + sizeof(uint)*(1 + blockSize + LBlockSize));
-
-    no_delete = true;
-    return sizeof(uint)*(1 + blockSize + LBlockSize) + MBlockSize;
-  }
-  
-  
-  uint ssv::getBlock(const uint blockPos) const {
-    return B[blockPos]; 
-  }
-
-  void ssv::setBlock(const uint blockPos, const uint x) {
-    B[blockPos] = x; 
-  }
-
-  uint ssv::getSize() const {
-    return size;
-  }
-
-  uint ssv::getBlockSize() const {
-    return blockSize;
-  }
-
-  uint ssv::popCount(uint r) const{
-    r = ((r & 0xAAAAAAAA) >> 1) + (r & 0x55555555);
-    r = ((r & 0xCCCCCCCC) >> 2) + (r & 0x33333333);
-    r = ((r >> 4) + r) & 0x0F0F0F0F;
-    r = (r>>8) + r;
-    return ((r>>16) + r) & 0x3F;
-  }
-
-  uint ssv::_rank1(const uint pos) const{
-    if (pos > size){
-      fprintf(stderr,"_rank1 range error pos:%d size:%d\n",pos,size);
-      return (uint)-1;
-    }
-    //printf("pos:%d size:%d lr:%d lp:%d mr:%d \n",pos,size,levelL[pos >> SSV_LBLOCK_SHIFT],pos >> SSV_LBLOCK_SHIFT,levelM[pos >> SSV_MBLOCK_SHIFT]);
-    return levelL[pos >> SSV_LBLOCK_SHIFT] + 
-      levelM[pos >> SSV_MBLOCK_SHIFT] + 
-      popCount((B[pos >> SSV_BLOCK_SHIFT] & ((1U << (pos  % SSV_BLOCK))-1)));
-  }
-
-  uint ssv::_select0(uint x) const{
-    uint left  = 0;
-    uint right = LBlockSize;
-    while (left < right){
-      uint mid = (left+right)/2;
-      if (SSV_LBLOCK * mid - levelL[mid] < x) left  = mid+1;
-      else                 right = mid;
-    }
-    uint posL = (left != 0) ? left-1: 0;
-
-    // sequential search over levelB
-    uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
-    x -= (SSV_LBLOCK*posL - levelL[posL]);
-
-    uint mstep = SSV_LBLOCK/SSV_MBLOCK;
-    while ((posM+1 < MBlockSize) && (((posM+1)%mstep) != 0) && (SSV_MBLOCK*((posM+1)%mstep)-levelM[posM+1] < x)){
-      posM++;
-    }
-
-    x -= (SSV_MBLOCK*(posM % mstep) - levelM[posM]);
-
-    uint ret    = posM * SSV_MBLOCK;
-    uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
-    uint rank32 = 32- popCount(B[posB]);
-    if (rank32 < x){
-      posB++;
-      ret += SSV_BLOCK;
-      x -= rank32;
-    }
-
-    uint curB   = B[posB];
-    uint rank16 = 16-popCount(curB & ((1U<<16)-1));
-    if (rank16 < x){
-      curB >>= 16;
-      ret += 16;
-      x -= rank16;
-    }
-
-    uint rank8  = 8-popCount(curB & ((1U << 8)-1));
-    if (rank8 < x){
-      curB >>= 8;
-      ret += 8;
-      x -= rank8;
-    }
-
-    while (x > 0){
-      if ((~curB) & 1){
-	x--;
-      }
-      curB >>= 1;
-      ret++;
-    }
-    return ret-1;
-  }
-
-  uint ssv::_select1(uint x) const{
-    uint left  = 0;
-    uint right = LBlockSize;
-    while (left < right){
-      uint mid = (left+right)/2;
-      if (levelL[mid] < x) left  = mid+1;
-      else                 right = mid;
-    }
-    uint posL = (left != 0) ? left-1: 0;
-
-    // sequential search over levelB
-    uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
-    x -= levelL[posL];
-    while ((posM+1 < MBlockSize) && (((posM+1)%(SSV_LBLOCK/SSV_MBLOCK)) != 0) && (levelM[posM+1] < x)){
-      posM++;
-    }
-
-    x -= levelM[posM];
-
-    uint ret    = posM * SSV_MBLOCK;
-    uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
-    uint rank32 = popCount(B[posB]);
-    if (rank32 < x){
-      posB++;
-      ret += SSV_BLOCK;
-      x -= rank32;
-    }
-
-    uint curB   = B[posB];
-    uint rank16 = popCount(curB & ((1U<<16)-1));
-    if (rank16 < x){
-      curB >>= 16;
-      ret += 16;
-      x -= rank16;
-    }
-
-    uint rank8  = popCount(curB & ((1U << 8)-1));
-    if (rank8 < x){
-      curB >>= 8;
-      ret += 8;
-      x -= rank8;
-    }
-
-    while (x > 0){
-      if (curB & 1){
-	x--;
-      }
-      curB >>= 1;
-      ret++;
-    }
-    return ret-1;
-  }
-
+ssv::ssv(const uint _size):
+  B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false) {
+  if (resize(_size) == -1) return;
 }
+
+ssv::ssv(std::vector<bool>& bv):
+  B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false) {
+  if (resize((uint)bv.size()) == -1) return;
+  for (uint i = 0; i < (uint)bv.size(); i++) {
+    setBit(i,bv[i]);
+  }
+}
+
+int ssv::resize(const uint _size) {
+  free();
+  size = _size;
+  blockSize = size/SSV_BLOCK + 1;
+  isBuild = false;
+  B = new uint [blockSize];
+  if (B == NULL) {
+    return -1;
+  }
+  memset(B,0,sizeof(uint)*blockSize);
+
+  LBlockSize = size / SSV_LBLOCK + 1;
+  MBlockSize = size / SSV_MBLOCK + 1;
+
+  levelL = new uint [LBlockSize];
+  levelM = new uchar [MBlockSize];
+  return 0;
+}
+
+void ssv::free() {
+  if (!no_delete) {
+    if (B) {
+      delete[] B;
+      B=NULL;
+    }
+  }
+  if (levelL) {
+    delete[] levelL;
+    levelL=NULL;
+  }
+  if (levelM) {
+    delete[] levelM;
+    levelM=NULL;
+  }
+}
+
+ssv::~ssv() {
+  free();
+}
+
+uint ssv::getBits(const uint pos, uint width) const {
+  assert(width <=32);
+  assert(pos+width <= size);
+  if (width == 0) return 0;
+
+  //---: block version
+  const uint endPos = pos+width-1;
+  const uint blockPos_1 = pos / SSV_BLOCK;
+  const uint blockPos_2 = endPos / SSV_BLOCK;
+  const uint offset_1   = pos % SSV_BLOCK;
+
+  if (blockPos_1 == blockPos_2) {
+    if (width == 32) {
+      return B[blockPos_1]; //avoid 1U << 32
+    }
+    else {
+      return (B[blockPos_1] >> offset_1) & ((1U << width) - 1);
+    }
+  }
+  else {
+    const uint offset_2   = endPos % SSV_BLOCK;
+    return  (B[blockPos_1] >> offset_1) + ((B[blockPos_2] & ((1U << (offset_2+1U))-1U)) << (32U-offset_1));
+  }
+}
+
+void ssv::setBits(const uint pos, const uint width, const uint x) {
+  assert(width <= 32);
+  assert(pos+width <= size);
+  if (width == 0) return;
+
+  //---: block version ----
+  const uint endPos     = pos+width-1;
+  const uint blockPos_1 = pos / SSV_BLOCK;
+  const uint blockPos_2 = endPos / SSV_BLOCK;
+  const uint offset_1   = pos % SSV_BLOCK;
+
+  if (blockPos_1 == blockPos_2) {
+    if (width == 32) {
+      B[blockPos_1] = x;
+    }
+    else {
+      B[blockPos_1] &= ~(((1U << width)-1) << offset_1); // |1111110000000111111|
+      B[blockPos_1] |= (x << offset_1);                  //        xxxxxxx
+    }
+  }
+  else {
+    const uint offset_2 = endPos % SSV_BLOCK;
+    B[blockPos_1] &= ((1U << offset_1)-1U);
+    B[blockPos_1] |= (x << offset_1);
+    B[blockPos_2] &= ~((1U << (offset_2+1U))-1U);
+    B[blockPos_2] |= (x >> (32-offset_1));
+  }
+}
+
+
+uint ssv::rank(uint pos, const uint bit) const {
+  pos++;
+  if (bit == 0) return pos-_rank1(pos);
+  else                  return _rank1(pos);
+}
+
+uint ssv::select(const uint pos, const uint bit) const {
+  if (bit) return _select1(pos);
+  else     return _select0(pos);
+}
+
+void ssv::setBit(uint pos, uint x) {
+  if (!x) B[pos / SSV_BLOCK] &= (~(1U << (pos % SSV_BLOCK)));
+  else    B[pos / SSV_BLOCK] |=   (1U << (pos % SSV_BLOCK));
+}
+
+uint ssv::getAllocate() const {
+  uint sum = size;
+  if (isBuild) {
+    sum += LBlockSize * 32 + MBlockSize * 8;
+  }
+  return sum;
+}
+
+void ssv::build() {
+  oneNum = rankBuild(size);
+  isBuild = true;
+}
+
+uint ssv::rankBuild(const uint t_size) {
+  uint sum = 0;
+  for (uint il = 0; il <= t_size ;il += SSV_LBLOCK) {
+    levelL[il/SSV_LBLOCK] = sum;
+    for (uint im = 0; im < SSV_LBLOCK && il+im <= t_size; im += SSV_MBLOCK) {
+      levelM[(il+im)/SSV_MBLOCK] = sum - levelL[il/SSV_LBLOCK];
+      for (uint is = 0; is < SSV_MBLOCK && (il+im+is) <= t_size; is += SSV_BLOCK) {
+        sum += popCount(B[(il+im+is)/SSV_BLOCK]);
+      }
+    }
+  }
+  return sum;
+}
+
+
+int ssv::write(FILE* outfp) {
+  if (fwrite(&size,sizeof(uint),1,outfp) != 1) {
+    return -1;
+  }
+  if (fwrite(B,sizeof(uint),blockSize,outfp) != blockSize) {
+    return -1;
+  }
+  if (fwrite(levelL,sizeof(uint),LBlockSize,outfp) != LBlockSize) {
+    return -1;
+  }
+  if (fwrite(levelM,sizeof(uchar),MBlockSize,outfp) != MBlockSize) {
+    return -1;
+  }
+  return 0;
+}
+
+int ssv::read(FILE* infp) {
+  if (fread(&size,sizeof(uint),1,infp) != 1) {
+    return -1;
+  }
+  if (resize(size) == -1) {
+    return -1;
+  }
+
+  if (fread(B,sizeof(uint),blockSize,infp) != blockSize) {
+    return -1;
+  }
+  isBuild = true;
+
+  if (fread(levelL,sizeof(uint),LBlockSize,infp) != LBlockSize) {
+    return -1;
+  }
+  if (fread(levelM,sizeof(uchar),MBlockSize,infp) != MBlockSize) {
+    return -1;
+  }
+  return 0;
+}
+
+size_t ssv::set_array(void* ptr) {
+  size = *(uint*)(ptr);
+
+  blockSize = size/SSV_BLOCK + 1;
+  isBuild = false;
+  LBlockSize = size / SSV_LBLOCK + 1;
+  MBlockSize = size / SSV_MBLOCK + 1;
+
+  B = ((uint*)ptr + 1);
+  levelL = ((uint*)ptr + 1 + blockSize);
+  levelM = ((uchar*)ptr + sizeof(uint)*(1 + blockSize + LBlockSize));
+
+  no_delete = true;
+  return sizeof(uint)*(1 + blockSize + LBlockSize) + MBlockSize;
+}
+
+
+uint ssv::getBlock(const uint blockPos) const {
+  return B[blockPos];
+}
+
+void ssv::setBlock(const uint blockPos, const uint x) {
+  B[blockPos] = x;
+}
+
+uint ssv::getSize() const {
+  return size;
+}
+
+uint ssv::getBlockSize() const {
+  return blockSize;
+}
+
+uint ssv::popCount(uint r) const {
+  r = ((r & 0xAAAAAAAA) >> 1) + (r & 0x55555555);
+  r = ((r & 0xCCCCCCCC) >> 2) + (r & 0x33333333);
+  r = ((r >> 4) + r) & 0x0F0F0F0F;
+  r = (r>>8) + r;
+  return ((r>>16) + r) & 0x3F;
+}
+
+uint ssv::_rank1(const uint pos) const {
+  if (pos > size) {
+    fprintf(stderr,"_rank1 range error pos:%d size:%d\n",pos,size);
+    return (uint)-1;
+  }
+  //printf("pos:%d size:%d lr:%d lp:%d mr:%d \n",pos,size,levelL[pos >> SSV_LBLOCK_SHIFT],pos >> SSV_LBLOCK_SHIFT,levelM[pos >> SSV_MBLOCK_SHIFT]);
+  return levelL[pos >> SSV_LBLOCK_SHIFT] +
+    levelM[pos >> SSV_MBLOCK_SHIFT] +
+    popCount((B[pos >> SSV_BLOCK_SHIFT] & ((1U << (pos  % SSV_BLOCK))-1)));
+}
+
+uint ssv::_select0(uint x) const {
+  uint left  = 0;
+  uint right = LBlockSize;
+  while (left < right) {
+    uint mid = (left+right)/2;
+    if (SSV_LBLOCK * mid - levelL[mid] < x) left  = mid+1;
+    else                 right = mid;
+  }
+  uint posL = (left != 0) ? left-1: 0;
+
+  // sequential search over levelB
+  uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
+  x -= (SSV_LBLOCK*posL - levelL[posL]);
+
+  uint mstep = SSV_LBLOCK/SSV_MBLOCK;
+  while ((posM+1 < MBlockSize) && (((posM+1)%mstep) != 0) && (SSV_MBLOCK*((posM+1)%mstep)-levelM[posM+1] < x)) {
+    posM++;
+  }
+
+  x -= (SSV_MBLOCK*(posM % mstep) - levelM[posM]);
+
+  uint ret    = posM * SSV_MBLOCK;
+  uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
+  uint rank32 = 32- popCount(B[posB]);
+  if (rank32 < x) {
+    posB++;
+    ret += SSV_BLOCK;
+    x -= rank32;
+  }
+
+  uint curB   = B[posB];
+  uint rank16 = 16-popCount(curB & ((1U<<16)-1));
+  if (rank16 < x) {
+    curB >>= 16;
+    ret += 16;
+    x -= rank16;
+  }
+
+  uint rank8  = 8-popCount(curB & ((1U << 8)-1));
+  if (rank8 < x) {
+    curB >>= 8;
+    ret += 8;
+    x -= rank8;
+  }
+
+  while (x > 0) {
+    if ((~curB) & 1) {
+      x--;
+    }
+    curB >>= 1;
+    ret++;
+  }
+  return ret-1;
+}
+
+uint ssv::_select1(uint x) const {
+  uint left  = 0;
+  uint right = LBlockSize;
+  while (left < right) {
+    uint mid = (left+right)/2;
+    if (levelL[mid] < x) left  = mid+1;
+    else                 right = mid;
+  }
+  uint posL = (left != 0) ? left-1: 0;
+
+  // sequential search over levelB
+  uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
+  x -= levelL[posL];
+  while ((posM+1 < MBlockSize) && (((posM+1)%(SSV_LBLOCK/SSV_MBLOCK)) != 0) && (levelM[posM+1] < x)) {
+    posM++;
+  }
+
+  x -= levelM[posM];
+
+  uint ret    = posM * SSV_MBLOCK;
+  uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
+  uint rank32 = popCount(B[posB]);
+  if (rank32 < x) {
+    posB++;
+    ret += SSV_BLOCK;
+    x -= rank32;
+  }
+
+  uint curB   = B[posB];
+  uint rank16 = popCount(curB & ((1U<<16)-1));
+  if (rank16 < x) {
+    curB >>= 16;
+    ret += 16;
+    x -= rank16;
+  }
+
+  uint rank8  = popCount(curB & ((1U << 8)-1));
+  if (rank8 < x) {
+    curB >>= 8;
+    ret += 8;
+    x -= rank8;
+  }
+
+  while (x > 0) {
+    if (curB & 1) {
+      x--;
+    }
+    curB >>= 1;
+    ret++;
+  }
+  return ret-1;
+}
+
+}  // namespace tx_tool

--- a/ssv.cpp
+++ b/ssv.cpp
@@ -21,35 +21,33 @@
 
 namespace tx_tool {
 
-ssv::ssv(const uint _size):
-  B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false) {
+ssv::ssv(const uint _size) : B(NULL), size(0), oneNum(0), levelL(NULL), levelM(NULL), no_delete(false) {
   if (resize(_size) == -1) return;
 }
 
-ssv::ssv(std::vector<bool>& bv):
-  B(NULL),size(0),oneNum(0),levelL(NULL),levelM(NULL), no_delete(false) {
+ssv::ssv(std::vector<bool>& bv) : B(NULL), size(0), oneNum(0), levelL(NULL), levelM(NULL), no_delete(false) {
   if (resize((uint)bv.size()) == -1) return;
   for (uint i = 0; i < (uint)bv.size(); i++) {
-    setBit(i,bv[i]);
+    setBit(i, bv[i]);
   }
 }
 
 int ssv::resize(const uint _size) {
   free();
   size = _size;
-  blockSize = size/SSV_BLOCK + 1;
+  blockSize = size / SSV_BLOCK + 1;
   isBuild = false;
-  B = new uint [blockSize];
+  B = new uint[blockSize];
   if (B == NULL) {
     return -1;
   }
-  memset(B,0,sizeof(uint)*blockSize);
+  memset(B, 0, sizeof(uint) * blockSize);
 
   LBlockSize = size / SSV_LBLOCK + 1;
   MBlockSize = size / SSV_MBLOCK + 1;
 
-  levelL = new uint [LBlockSize];
-  levelM = new uchar [MBlockSize];
+  levelL = new uint[LBlockSize];
+  levelM = new uchar[MBlockSize];
   return 0;
 }
 
@@ -57,16 +55,16 @@ void ssv::free() {
   if (!no_delete) {
     if (B) {
       delete[] B;
-      B=NULL;
+      B = NULL;
     }
   }
   if (levelL) {
     delete[] levelL;
-    levelL=NULL;
+    levelL = NULL;
   }
   if (levelM) {
     delete[] levelM;
-    levelM=NULL;
+    levelM = NULL;
   }
 }
 
@@ -75,74 +73,75 @@ ssv::~ssv() {
 }
 
 uint ssv::getBits(const uint pos, uint width) const {
-  assert(width <=32);
-  assert(pos+width <= size);
+  assert(width <= 32);
+  assert(pos + width <= size);
   if (width == 0) return 0;
 
   //---: block version
-  const uint endPos = pos+width-1;
+  const uint endPos = pos + width - 1;
   const uint blockPos_1 = pos / SSV_BLOCK;
   const uint blockPos_2 = endPos / SSV_BLOCK;
-  const uint offset_1   = pos % SSV_BLOCK;
+  const uint offset_1 = pos % SSV_BLOCK;
 
   if (blockPos_1 == blockPos_2) {
     if (width == 32) {
-      return B[blockPos_1]; //avoid 1U << 32
-    }
-    else {
+      return B[blockPos_1];  // avoid 1U << 32
+    } else {
       return (B[blockPos_1] >> offset_1) & ((1U << width) - 1);
     }
-  }
-  else {
-    const uint offset_2   = endPos % SSV_BLOCK;
-    return  (B[blockPos_1] >> offset_1) + ((B[blockPos_2] & ((1U << (offset_2+1U))-1U)) << (32U-offset_1));
+  } else {
+    const uint offset_2 = endPos % SSV_BLOCK;
+    return (B[blockPos_1] >> offset_1) + ((B[blockPos_2] & ((1U << (offset_2 + 1U)) - 1U)) << (32U - offset_1));
   }
 }
 
 void ssv::setBits(const uint pos, const uint width, const uint x) {
   assert(width <= 32);
-  assert(pos+width <= size);
+  assert(pos + width <= size);
   if (width == 0) return;
 
   //---: block version ----
-  const uint endPos     = pos+width-1;
+  const uint endPos = pos + width - 1;
   const uint blockPos_1 = pos / SSV_BLOCK;
   const uint blockPos_2 = endPos / SSV_BLOCK;
-  const uint offset_1   = pos % SSV_BLOCK;
+  const uint offset_1 = pos % SSV_BLOCK;
 
   if (blockPos_1 == blockPos_2) {
     if (width == 32) {
       B[blockPos_1] = x;
+    } else {
+      B[blockPos_1] &= ~(((1U << width) - 1) << offset_1);  // |1111110000000111111|
+      B[blockPos_1] |= (x << offset_1);                     //        xxxxxxx
     }
-    else {
-      B[blockPos_1] &= ~(((1U << width)-1) << offset_1); // |1111110000000111111|
-      B[blockPos_1] |= (x << offset_1);                  //        xxxxxxx
-    }
-  }
-  else {
+  } else {
     const uint offset_2 = endPos % SSV_BLOCK;
-    B[blockPos_1] &= ((1U << offset_1)-1U);
+    B[blockPos_1] &= ((1U << offset_1) - 1U);
     B[blockPos_1] |= (x << offset_1);
-    B[blockPos_2] &= ~((1U << (offset_2+1U))-1U);
-    B[blockPos_2] |= (x >> (32-offset_1));
+    B[blockPos_2] &= ~((1U << (offset_2 + 1U)) - 1U);
+    B[blockPos_2] |= (x >> (32 - offset_1));
   }
 }
-
 
 uint ssv::rank(uint pos, const uint bit) const {
   pos++;
-  if (bit == 0) return pos-_rank1(pos);
-  else                  return _rank1(pos);
+  if (bit == 0)
+    return pos - _rank1(pos);
+  else
+    return _rank1(pos);
 }
 
 uint ssv::select(const uint pos, const uint bit) const {
-  if (bit) return _select1(pos);
-  else     return _select0(pos);
+  if (bit)
+    return _select1(pos);
+  else
+    return _select0(pos);
 }
 
 void ssv::setBit(uint pos, uint x) {
-  if (!x) B[pos / SSV_BLOCK] &= (~(1U << (pos % SSV_BLOCK)));
-  else    B[pos / SSV_BLOCK] |=   (1U << (pos % SSV_BLOCK));
+  if (!x)
+    B[pos / SSV_BLOCK] &= (~(1U << (pos % SSV_BLOCK)));
+  else
+    B[pos / SSV_BLOCK] |= (1U << (pos % SSV_BLOCK));
 }
 
 uint ssv::getAllocate() const {
@@ -160,52 +159,51 @@ void ssv::build() {
 
 uint ssv::rankBuild(const uint t_size) {
   uint sum = 0;
-  for (uint il = 0; il <= t_size ;il += SSV_LBLOCK) {
-    levelL[il/SSV_LBLOCK] = sum;
-    for (uint im = 0; im < SSV_LBLOCK && il+im <= t_size; im += SSV_MBLOCK) {
-      levelM[(il+im)/SSV_MBLOCK] = sum - levelL[il/SSV_LBLOCK];
-      for (uint is = 0; is < SSV_MBLOCK && (il+im+is) <= t_size; is += SSV_BLOCK) {
-        sum += popCount(B[(il+im+is)/SSV_BLOCK]);
+  for (uint il = 0; il <= t_size; il += SSV_LBLOCK) {
+    levelL[il / SSV_LBLOCK] = sum;
+    for (uint im = 0; im < SSV_LBLOCK && il + im <= t_size; im += SSV_MBLOCK) {
+      levelM[(il + im) / SSV_MBLOCK] = sum - levelL[il / SSV_LBLOCK];
+      for (uint is = 0; is < SSV_MBLOCK && (il + im + is) <= t_size; is += SSV_BLOCK) {
+        sum += popCount(B[(il + im + is) / SSV_BLOCK]);
       }
     }
   }
   return sum;
 }
 
-
 int ssv::write(FILE* outfp) {
-  if (fwrite(&size,sizeof(uint),1,outfp) != 1) {
+  if (fwrite(&size, sizeof(uint), 1, outfp) != 1) {
     return -1;
   }
-  if (fwrite(B,sizeof(uint),blockSize,outfp) != blockSize) {
+  if (fwrite(B, sizeof(uint), blockSize, outfp) != blockSize) {
     return -1;
   }
-  if (fwrite(levelL,sizeof(uint),LBlockSize,outfp) != LBlockSize) {
+  if (fwrite(levelL, sizeof(uint), LBlockSize, outfp) != LBlockSize) {
     return -1;
   }
-  if (fwrite(levelM,sizeof(uchar),MBlockSize,outfp) != MBlockSize) {
+  if (fwrite(levelM, sizeof(uchar), MBlockSize, outfp) != MBlockSize) {
     return -1;
   }
   return 0;
 }
 
 int ssv::read(FILE* infp) {
-  if (fread(&size,sizeof(uint),1,infp) != 1) {
+  if (fread(&size, sizeof(uint), 1, infp) != 1) {
     return -1;
   }
   if (resize(size) == -1) {
     return -1;
   }
 
-  if (fread(B,sizeof(uint),blockSize,infp) != blockSize) {
+  if (fread(B, sizeof(uint), blockSize, infp) != blockSize) {
     return -1;
   }
   isBuild = true;
 
-  if (fread(levelL,sizeof(uint),LBlockSize,infp) != LBlockSize) {
+  if (fread(levelL, sizeof(uint), LBlockSize, infp) != LBlockSize) {
     return -1;
   }
-  if (fread(levelM,sizeof(uchar),MBlockSize,infp) != MBlockSize) {
+  if (fread(levelM, sizeof(uchar), MBlockSize, infp) != MBlockSize) {
     return -1;
   }
   return 0;
@@ -214,19 +212,18 @@ int ssv::read(FILE* infp) {
 size_t ssv::set_array(void* ptr) {
   size = *(uint*)(ptr);
 
-  blockSize = size/SSV_BLOCK + 1;
+  blockSize = size / SSV_BLOCK + 1;
   isBuild = false;
   LBlockSize = size / SSV_LBLOCK + 1;
   MBlockSize = size / SSV_MBLOCK + 1;
 
   B = ((uint*)ptr + 1);
   levelL = ((uint*)ptr + 1 + blockSize);
-  levelM = ((uchar*)ptr + sizeof(uint)*(1 + blockSize + LBlockSize));
+  levelM = ((uchar*)ptr + sizeof(uint) * (1 + blockSize + LBlockSize));
 
   no_delete = true;
-  return sizeof(uint)*(1 + blockSize + LBlockSize) + MBlockSize;
+  return sizeof(uint) * (1 + blockSize + LBlockSize) + MBlockSize;
 }
-
 
 uint ssv::getBlock(const uint blockPos) const {
   return B[blockPos];
@@ -248,60 +245,60 @@ uint ssv::popCount(uint r) const {
   r = ((r & 0xAAAAAAAA) >> 1) + (r & 0x55555555);
   r = ((r & 0xCCCCCCCC) >> 2) + (r & 0x33333333);
   r = ((r >> 4) + r) & 0x0F0F0F0F;
-  r = (r>>8) + r;
-  return ((r>>16) + r) & 0x3F;
+  r = (r >> 8) + r;
+  return ((r >> 16) + r) & 0x3F;
 }
 
 uint ssv::_rank1(const uint pos) const {
   if (pos > size) {
-    fprintf(stderr,"_rank1 range error pos:%d size:%d\n",pos,size);
+    fprintf(stderr, "_rank1 range error pos:%d size:%d\n", pos, size);
     return (uint)-1;
   }
-  //printf("pos:%d size:%d lr:%d lp:%d mr:%d \n",pos,size,levelL[pos >> SSV_LBLOCK_SHIFT],pos >> SSV_LBLOCK_SHIFT,levelM[pos >> SSV_MBLOCK_SHIFT]);
-  return levelL[pos >> SSV_LBLOCK_SHIFT] +
-    levelM[pos >> SSV_MBLOCK_SHIFT] +
-    popCount((B[pos >> SSV_BLOCK_SHIFT] & ((1U << (pos  % SSV_BLOCK))-1)));
+  // printf("pos:%d size:%d lr:%d lp:%d mr:%d \n",pos,size,levelL[pos >> SSV_LBLOCK_SHIFT],pos >> SSV_LBLOCK_SHIFT,levelM[pos >> SSV_MBLOCK_SHIFT]);
+  return levelL[pos >> SSV_LBLOCK_SHIFT] + levelM[pos >> SSV_MBLOCK_SHIFT] + popCount((B[pos >> SSV_BLOCK_SHIFT] & ((1U << (pos % SSV_BLOCK)) - 1)));
 }
 
 uint ssv::_select0(uint x) const {
-  uint left  = 0;
+  uint left = 0;
   uint right = LBlockSize;
   while (left < right) {
-    uint mid = (left+right)/2;
-    if (SSV_LBLOCK * mid - levelL[mid] < x) left  = mid+1;
-    else                 right = mid;
+    uint mid = (left + right) / 2;
+    if (SSV_LBLOCK * mid - levelL[mid] < x)
+      left = mid + 1;
+    else
+      right = mid;
   }
-  uint posL = (left != 0) ? left-1: 0;
+  uint posL = (left != 0) ? left - 1 : 0;
 
   // sequential search over levelB
-  uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
-  x -= (SSV_LBLOCK*posL - levelL[posL]);
+  uint posM = posL * (SSV_LBLOCK / SSV_MBLOCK);
+  x -= (SSV_LBLOCK * posL - levelL[posL]);
 
-  uint mstep = SSV_LBLOCK/SSV_MBLOCK;
-  while ((posM+1 < MBlockSize) && (((posM+1)%mstep) != 0) && (SSV_MBLOCK*((posM+1)%mstep)-levelM[posM+1] < x)) {
+  uint mstep = SSV_LBLOCK / SSV_MBLOCK;
+  while ((posM + 1 < MBlockSize) && (((posM + 1) % mstep) != 0) && (SSV_MBLOCK * ((posM + 1) % mstep) - levelM[posM + 1] < x)) {
     posM++;
   }
 
-  x -= (SSV_MBLOCK*(posM % mstep) - levelM[posM]);
+  x -= (SSV_MBLOCK * (posM % mstep) - levelM[posM]);
 
-  uint ret    = posM * SSV_MBLOCK;
-  uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
-  uint rank32 = 32- popCount(B[posB]);
+  uint ret = posM * SSV_MBLOCK;
+  uint posB = posM * (SSV_MBLOCK / SSV_BLOCK);
+  uint rank32 = 32 - popCount(B[posB]);
   if (rank32 < x) {
     posB++;
     ret += SSV_BLOCK;
     x -= rank32;
   }
 
-  uint curB   = B[posB];
-  uint rank16 = 16-popCount(curB & ((1U<<16)-1));
+  uint curB = B[posB];
+  uint rank16 = 16 - popCount(curB & ((1U << 16) - 1));
   if (rank16 < x) {
     curB >>= 16;
     ret += 16;
     x -= rank16;
   }
 
-  uint rank8  = 8-popCount(curB & ((1U << 8)-1));
+  uint rank8 = 8 - popCount(curB & ((1U << 8) - 1));
   if (rank8 < x) {
     curB >>= 8;
     ret += 8;
@@ -315,30 +312,32 @@ uint ssv::_select0(uint x) const {
     curB >>= 1;
     ret++;
   }
-  return ret-1;
+  return ret - 1;
 }
 
 uint ssv::_select1(uint x) const {
-  uint left  = 0;
+  uint left = 0;
   uint right = LBlockSize;
   while (left < right) {
-    uint mid = (left+right)/2;
-    if (levelL[mid] < x) left  = mid+1;
-    else                 right = mid;
+    uint mid = (left + right) / 2;
+    if (levelL[mid] < x)
+      left = mid + 1;
+    else
+      right = mid;
   }
-  uint posL = (left != 0) ? left-1: 0;
+  uint posL = (left != 0) ? left - 1 : 0;
 
   // sequential search over levelB
-  uint posM = posL * (SSV_LBLOCK/SSV_MBLOCK);
+  uint posM = posL * (SSV_LBLOCK / SSV_MBLOCK);
   x -= levelL[posL];
-  while ((posM+1 < MBlockSize) && (((posM+1)%(SSV_LBLOCK/SSV_MBLOCK)) != 0) && (levelM[posM+1] < x)) {
+  while ((posM + 1 < MBlockSize) && (((posM + 1) % (SSV_LBLOCK / SSV_MBLOCK)) != 0) && (levelM[posM + 1] < x)) {
     posM++;
   }
 
   x -= levelM[posM];
 
-  uint ret    = posM * SSV_MBLOCK;
-  uint posB   = posM * (SSV_MBLOCK/SSV_BLOCK);
+  uint ret = posM * SSV_MBLOCK;
+  uint posB = posM * (SSV_MBLOCK / SSV_BLOCK);
   uint rank32 = popCount(B[posB]);
   if (rank32 < x) {
     posB++;
@@ -346,15 +345,15 @@ uint ssv::_select1(uint x) const {
     x -= rank32;
   }
 
-  uint curB   = B[posB];
-  uint rank16 = popCount(curB & ((1U<<16)-1));
+  uint curB = B[posB];
+  uint rank16 = popCount(curB & ((1U << 16) - 1));
   if (rank16 < x) {
     curB >>= 16;
     ret += 16;
     x -= rank16;
   }
 
-  uint rank8  = popCount(curB & ((1U << 8)-1));
+  uint rank8 = popCount(curB & ((1U << 8) - 1));
   if (rank8 < x) {
     curB >>= 8;
     ret += 8;
@@ -368,7 +367,7 @@ uint ssv::_select1(uint x) const {
     curB >>= 1;
     ret++;
   }
-  return ret-1;
+  return ret - 1;
 }
 
 }  // namespace tx_tool

--- a/ssv.hpp
+++ b/ssv.hpp
@@ -32,20 +32,13 @@ typedef unsigned int uint;      // 32bit
 typedef unsigned short ushort;  // 16bit
 typedef unsigned char uchar;    // 8bit
 
-#define SSV_BLOCK_SHIFT (5)
-#define SSV_BLOCK (1U << SSV_BLOCK_SHIFT)
+const uint SSV_BLOCK_SHIFT = 5;
+const uint SSV_BLOCK = (1U << SSV_BLOCK_SHIFT);
 
-#define SSV_LBLOCK_SHIFT (8)
-#define SSV_LBLOCK (1U << SSV_LBLOCK_SHIFT)
-#define SSV_MBLOCK_SHIFT (5)
-#define SSV_MBLOCK (1U << SSV_MBLOCK_SHIFT)
-
-#define logLL (16)
-#define LL (1U << logLL)
-#define logLLL (5)
-#define LLL (1U << logLLL)
-#define logL (logLL - 1 - 5)
-#define L (1U << logL)
+const uint SSV_LBLOCK_SHIFT = 8;
+const uint SSV_LBLOCK = (1U << SSV_LBLOCK_SHIFT);
+const uint SSV_MBLOCK_SHIFT = 5;
+const uint SSV_MBLOCK = (1U << SSV_MBLOCK_SHIFT);
 
 class ssv {
  public:

--- a/ssv.hpp
+++ b/ssv.hpp
@@ -1,10 +1,10 @@
-/* 
+/*
  *  Copyright (c) 2007-2010 Daisuke Okanohara
- * 
+ *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
- * 
+ *
  *   1. Redistributions of source code must retain the above Copyright
  *      notice, this list of conditions and the following disclaimer.
  *
@@ -25,18 +25,18 @@
 #include <cassert>
 #include <stdio.h>
 
-namespace tx_tool{
+namespace tx_tool {
 
-  typedef unsigned int uint; // 32bit
-  typedef unsigned short ushort; // 16bit
-  typedef unsigned char uchar; // 8bit
+typedef unsigned int uint; // 32bit
+typedef unsigned short ushort; // 16bit
+typedef unsigned char uchar; // 8bit
 
 
 #define SSV_BLOCK_SHIFT  (5)
 #define SSV_BLOCK        (1U << SSV_BLOCK_SHIFT)
 
 #define SSV_LBLOCK_SHIFT (8)
-#define SSV_LBLOCK		 (1U << SSV_LBLOCK_SHIFT)
+#define SSV_LBLOCK               (1U << SSV_LBLOCK_SHIFT)
 #define SSV_MBLOCK_SHIFT (5)
 #define SSV_MBLOCK       (1U << SSV_MBLOCK_SHIFT)
 
@@ -47,66 +47,66 @@ namespace tx_tool{
 #define logL (logLL-1-5)
 #define L (1U << logL)
 
-  class ssv{
+class ssv {
 
-  public:
-    ssv(const uint _size = 0);
-    ssv(std::vector<bool>& bv);
+public:
+  ssv(const uint _size = 0);
+  ssv(std::vector<bool>& bv);
 
-    int resize(const uint _size);
+  int resize(const uint _size);
 
-    void free();
+  void free();
 
-    ~ssv();
+  ~ssv();
 
-    inline uint getBit(const uint pos) const {
-      return (B[pos / SSV_BLOCK] >> (pos % SSV_BLOCK)) & 1;
-    }
+  inline uint getBit(const uint pos) const {
+    return (B[pos / SSV_BLOCK] >> (pos % SSV_BLOCK)) & 1;
+  }
 
-    uint getBits(const uint pos, uint width) const;
-    void setBits(const uint pos, const uint width, const uint x);
-    uint rank(uint pos, const uint bit) const;
-    uint select(uint pos, const uint bit) const;
+  uint getBits(const uint pos, uint width) const;
+  void setBits(const uint pos, const uint width, const uint x);
+  uint rank(uint pos, const uint bit) const;
+  uint select(uint pos, const uint bit) const;
 
-    void setBit(uint pos, uint x);
-    uint getAllocate() const;
+  void setBit(uint pos, uint x);
+  uint getAllocate() const;
 
-    void build();
+  void build();
 
-    uint rankBuild(const uint t_size); // return oneNum
-    void selectBuild(const uint t_size);
+  uint rankBuild(const uint t_size); // return oneNum
+  void selectBuild(const uint t_size);
 
-    int write(FILE* outfp);
-    int read(FILE* infp);
+  int write(FILE* outfp);
+  int read(FILE* infp);
 
-    uint getBlock(const uint blockPos) const;
-    void setBlock(const uint blockPos, const uint x);
-    uint getSize() const;
-    uint getBlockSize() const;
+  uint getBlock(const uint blockPos) const;
+  void setBlock(const uint blockPos, const uint x);
+  uint getSize() const;
+  uint getBlockSize() const;
 
-    size_t set_array(void* ptr);
+  size_t set_array(void* ptr);
 
-  private:
-    uint popCount(uint r) const;
-    uint _rank1(const uint pos) const;
-    uint _select1(uint x) const;
-    uint _select0(uint x) const;
-    uint* B;
-    uint size;
-    uint oneNum;
-    uint blockSize;	// (size+SSV_BLOCK-1)/SSV_BLOCKSZIE
+private:
+  uint popCount(uint r) const;
+  uint _rank1(const uint pos) const;
+  uint _select1(uint x) const;
+  uint _select0(uint x) const;
+  uint* B;
+  uint size;
+  uint oneNum;
+  uint blockSize;     // (size+SSV_BLOCK-1)/SSV_BLOCKSZIE
 
-    uint LBlockSize;
-    uint MBlockSize;
+  uint LBlockSize;
+  uint MBlockSize;
 
-    // for rank
-    uint* levelL;
-    uchar* levelM;
+  // for rank
+  uint* levelL;
+  uchar* levelM;
 
-    bool isBuild;
-    bool no_delete;
-  };
+  bool isBuild;
+  bool no_delete;
+};
 
-}
+}  // namespace tx_tool
 
 #endif

--- a/ssv.hpp
+++ b/ssv.hpp
@@ -17,8 +17,8 @@
  *      software without specific prior written permission.
  */
 
-#ifndef __SSV_HPP__
-#define __SSV_HPP__
+#ifndef TXTRIE_SSV_HPP_
+#define TXTRIE_SSV_HPP_
 
 #include <memory.h>
 #include <stdio.h>
@@ -108,4 +108,4 @@ class ssv {
 
 }  // namespace tx_tool
 
-#endif
+#endif  // TXTRIE_SSV_HPP_

--- a/ssv.hpp
+++ b/ssv.hpp
@@ -21,35 +21,34 @@
 #define __SSV_HPP__
 
 #include <memory.h>
-#include <vector>
-#include <cassert>
 #include <stdio.h>
+
+#include <cassert>
+#include <vector>
 
 namespace tx_tool {
 
-typedef unsigned int uint; // 32bit
-typedef unsigned short ushort; // 16bit
-typedef unsigned char uchar; // 8bit
+typedef unsigned int uint;      // 32bit
+typedef unsigned short ushort;  // 16bit
+typedef unsigned char uchar;    // 8bit
 
-
-#define SSV_BLOCK_SHIFT  (5)
-#define SSV_BLOCK        (1U << SSV_BLOCK_SHIFT)
+#define SSV_BLOCK_SHIFT (5)
+#define SSV_BLOCK (1U << SSV_BLOCK_SHIFT)
 
 #define SSV_LBLOCK_SHIFT (8)
-#define SSV_LBLOCK               (1U << SSV_LBLOCK_SHIFT)
+#define SSV_LBLOCK (1U << SSV_LBLOCK_SHIFT)
 #define SSV_MBLOCK_SHIFT (5)
-#define SSV_MBLOCK       (1U << SSV_MBLOCK_SHIFT)
+#define SSV_MBLOCK (1U << SSV_MBLOCK_SHIFT)
 
 #define logLL (16)
 #define LL (1U << logLL)
 #define logLLL (5)
 #define LLL (1U << logLLL)
-#define logL (logLL-1-5)
+#define logL (logLL - 1 - 5)
 #define L (1U << logL)
 
 class ssv {
-
-public:
+ public:
   ssv(const uint _size = 0);
   ssv(std::vector<bool>& bv);
 
@@ -73,7 +72,7 @@ public:
 
   void build();
 
-  uint rankBuild(const uint t_size); // return oneNum
+  uint rankBuild(const uint t_size);  // return oneNum
   void selectBuild(const uint t_size);
 
   int write(FILE* outfp);
@@ -86,7 +85,7 @@ public:
 
   size_t set_array(void* ptr);
 
-private:
+ private:
   uint popCount(uint r) const;
   uint _rank1(const uint pos) const;
   uint _select1(uint x) const;
@@ -94,7 +93,7 @@ private:
   uint* B;
   uint size;
   uint oneNum;
-  uint blockSize;     // (size+SSV_BLOCK-1)/SSV_BLOCKSZIE
+  uint blockSize;  // (size+SSV_BLOCK-1)/SSV_BLOCKSZIE
 
   uint LBlockSize;
   uint MBlockSize;

--- a/tx.cpp
+++ b/tx.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "tx.hpp"
+
 #include "ssv.hpp"
 namespace tx_tool{
 
@@ -319,7 +320,6 @@ namespace tx_tool{
     return (uint)retLen.size();
   }
 
-  
   uint tx::predictiveSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID, const uint limit) const{
     ret.clear();
     retID.clear();
@@ -380,8 +380,6 @@ namespace tx_tool{
     return (uint)retLen.size();
   }
 
-
-
   void tx::enumerateAll(const uint pos, const std::string str, std::vector<std::pair<size_t, std::pair<std::string, uint> > >& ret) const{
     const uint nodeId = loud.rank(pos-1,1)-1;
     if (terminal.getBit(nodeId)){
@@ -420,7 +418,6 @@ namespace tx_tool{
     return loud.select(loud.rank(pos-1, 1), 0);
   }
 
-
   uint tx::reverseLookup(const uint id, std::string& ret) const {
     ret.clear();
     if (id >= keyNum) return 0;
@@ -449,6 +446,5 @@ namespace tx_tool{
   uint tx::getKeyNum() const {
     return keyNum;
   }
-
 
 } // namespace tx_tool

--- a/tx.hpp
+++ b/tx.hpp
@@ -20,15 +20,16 @@
 #ifndef __TX_HPP__
 #define __TX_HPP__
 
-#include <string>
-#include <iostream>
-#include <vector>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include <algorithm>
+#include <iostream>
 #include <queue>
 #include <sstream>
-#include <limits.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <string>
+#include <vector>
 
 #include "ssv.hpp"
 
@@ -37,19 +38,18 @@ namespace tx_tool {
 #define TX_LIMIT_DEFAULT (0xffffffff)
 
 class tx {
-
-public:
+ public:
   tx();
   ~tx();
-  int build(std::vector<std::string>& wordList, const char* fileName) ;
+  int build(std::vector<std::string>& wordList, const char* fileName);
   int read(const char* fileName);
 
   uint prefixSearch(const char* str, const size_t len, size_t& retLen) const;
   uint expandSearch(const char* str, const size_t len, std::vector<std::string>& ret, const uint limit = 0) const;
-  uint commonPrefixSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
-  uint commonPrefixSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
+  uint commonPrefixSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
+  uint commonPrefixSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
   uint predictiveSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
-  uint predictiveSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
+  uint predictiveSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
 
   uint reverseLookup(const uint id, std::string& ret) const;
 
@@ -61,7 +61,7 @@ public:
 
   static uint NOTFOUND;
 
-private:
+ private:
   uint getChild(const uint pos, const char c) const;
   uint getParent(const uint pos, char& c) const;
   void enumerateAll(const uint pos, const std::string str, std::vector<std::pair<size_t, std::pair<std::string, uint> > >& ret) const;
@@ -78,4 +78,4 @@ private:
 
 }  // namespace tx_tool
 
-#endif // __TX_HPP__
+#endif  // __TX_HPP__

--- a/tx.hpp
+++ b/tx.hpp
@@ -35,7 +35,7 @@
 
 namespace tx_tool {
 
-#define TX_LIMIT_DEFAULT (0xffffffff)
+const uint64_t TX_LIMIT_DEFAULT = 0xffffffff;
 
 class tx {
  public:

--- a/tx.hpp
+++ b/tx.hpp
@@ -17,8 +17,8 @@
  *      software without specific prior written permission.
  */
 
-#ifndef __TX_HPP__
-#define __TX_HPP__
+#ifndef TXTRIE_TX_HPP_
+#define TXTRIE_TX_HPP_
 
 #include <limits.h>
 #include <sys/stat.h>
@@ -78,4 +78,4 @@ class tx {
 
 }  // namespace tx_tool
 
-#endif  // __TX_HPP__
+#endif  // TXTRIE_SSV_HPP_

--- a/tx.hpp
+++ b/tx.hpp
@@ -1,10 +1,10 @@
-/* 
+/*
  *  Copyright (c) 2007-2010 Daisuke Okanohara
- * 
+ *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
- * 
+ *
  *   1. Redistributions of source code must retain the above Copyright
  *      notice, this list of conditions and the following disclaimer.
  *
@@ -32,50 +32,50 @@
 
 #include "ssv.hpp"
 
-namespace tx_tool{
+namespace tx_tool {
 
 #define TX_LIMIT_DEFAULT (0xffffffff)
 
-  class tx{
+class tx {
 
-  public:
-    tx();
-    ~tx();
-    int build(std::vector<std::string>& wordList, const char* fileName) ;
-    int read(const char* fileName);
+public:
+  tx();
+  ~tx();
+  int build(std::vector<std::string>& wordList, const char* fileName) ;
+  int read(const char* fileName);
 
-    uint prefixSearch(const char* str, const size_t len, size_t& retLen) const;
-    uint expandSearch(const char* str, const size_t len, std::vector<std::string>& ret, const uint limit = 0) const;
-    uint commonPrefixSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
-    uint commonPrefixSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
-    uint predictiveSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
-    uint predictiveSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
+  uint prefixSearch(const char* str, const size_t len, size_t& retLen) const;
+  uint expandSearch(const char* str, const size_t len, std::vector<std::string>& ret, const uint limit = 0) const;
+  uint commonPrefixSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
+  uint commonPrefixSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
+  uint predictiveSearch(const char* str, const size_t len, std::vector<std::string>& ret, std::vector<uint>& retID, const uint limit = TX_LIMIT_DEFAULT) const;
+  uint predictiveSearch(const char* str, const size_t len, std::vector<uint>& retLen, std::vector<uint>& retID,  const uint limit = TX_LIMIT_DEFAULT) const;
 
-    uint reverseLookup(const uint id, std::string& ret) const;
+  uint reverseLookup(const uint id, std::string& ret) const;
 
-    std::string getResultLog() const;
-    std::string getErrorLog() const;
+  std::string getResultLog() const;
+  std::string getErrorLog() const;
 
-    int setArray(void* ptr, size_t readSize);
-    uint getKeyNum() const;
-    
-    static uint NOTFOUND;
-    
-  private:
-    uint getChild(const uint pos, const char c) const;
-    uint getParent(const uint pos, char& c) const;
-    void enumerateAll(const uint pos, const std::string str, std::vector<std::pair<size_t, std::pair<std::string, uint> > >& ret) const; 
-    ssv loud;
-    ssv terminal;
-    char* edge;
+  int setArray(void* ptr, size_t readSize);
+  uint getKeyNum() const;
 
-    size_t keyNum;
-    std::ostringstream resultLog;
-    std::ostringstream errorLog;
+  static uint NOTFOUND;
 
-    bool no_delete;
-  };
+private:
+  uint getChild(const uint pos, const char c) const;
+  uint getParent(const uint pos, char& c) const;
+  void enumerateAll(const uint pos, const std::string str, std::vector<std::pair<size_t, std::pair<std::string, uint> > >& ret) const;
+  ssv loud;
+  ssv terminal;
+  char* edge;
 
-}
+  size_t keyNum;
+  std::ostringstream resultLog;
+  std::ostringstream errorLog;
+
+  bool no_delete;
+};
+
+}  // namespace tx_tool
 
 #endif // __TX_HPP__

--- a/txbuild.cpp
+++ b/txbuild.cpp
@@ -1,10 +1,10 @@
-/* 
+/*
  *  Copyright (c) 2007-2010 Daisuke Okanohara
- * 
+ *
  *   Redistribution and use in source and binary forms, with or without
  *   modification, are permitted provided that the following conditions
  *   are met:
- * 
+ *
  *   1. Redistributions of source code must retain the above Copyright
  *      notice, this list of conditions and the following disclaimer.
  *
@@ -22,8 +22,8 @@
 #include <vector>
 #include "tx.hpp"
 
-int main(int argc, char* argv[]){
-  if (argc != 3){
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
     fprintf(stderr,"%s wordlist index\n",argv[0]);
     return -1;
   }
@@ -31,16 +31,16 @@ int main(int argc, char* argv[]){
   std::vector<std::string> wordList;
   {
     std::ifstream ifs(argv[1]);
-    if (!ifs){
+    if (!ifs) {
       fprintf(stderr,"cannot open %s\n",argv[1]);
       return -1;
     }
 
     std::string word;
-    while (getline(ifs, word)){
+    while (getline(ifs, word)) {
       // handle CR-LF
-      if (word.size() > 0 && word[word.size()-1] == '\r'){
-	word = word.substr(0, word.size()-1);
+      if (word.size() > 0 && word[word.size()-1] == '\r') {
+        word = word.substr(0, word.size()-1);
       }
       if (word == "") continue;
       wordList.push_back(word);
@@ -48,12 +48,12 @@ int main(int argc, char* argv[]){
   }
 
   tx_tool::tx t;
-  if (t.build(wordList,argv[2]) == -1){
+  if (t.build(wordList,argv[2]) == -1) {
     fprintf(stderr, "%s", t.getErrorLog().c_str());
     fprintf(stderr, "cannot build index for %s\n",argv[1]);
     return -1;
   }
   fprintf(stderr, "%s", t.getResultLog().c_str());
-  
+
   return 0;
 }

--- a/txbuild.cpp
+++ b/txbuild.cpp
@@ -17,14 +17,15 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
 #include <fstream>
+#include <string>
 #include <vector>
+
 #include "tx.hpp"
 
 int main(int argc, char* argv[]) {
   if (argc != 3) {
-    fprintf(stderr,"%s wordlist index\n",argv[0]);
+    fprintf(stderr, "%s wordlist index\n", argv[0]);
     return -1;
   }
 
@@ -32,15 +33,15 @@ int main(int argc, char* argv[]) {
   {
     std::ifstream ifs(argv[1]);
     if (!ifs) {
-      fprintf(stderr,"cannot open %s\n",argv[1]);
+      fprintf(stderr, "cannot open %s\n", argv[1]);
       return -1;
     }
 
     std::string word;
     while (getline(ifs, word)) {
       // handle CR-LF
-      if (word.size() > 0 && word[word.size()-1] == '\r') {
-        word = word.substr(0, word.size()-1);
+      if (word.size() > 0 && word[word.size() - 1] == '\r') {
+        word = word.substr(0, word.size() - 1);
       }
       if (word == "") continue;
       wordList.push_back(word);
@@ -48,9 +49,9 @@ int main(int argc, char* argv[]) {
   }
 
   tx_tool::tx t;
-  if (t.build(wordList,argv[2]) == -1) {
+  if (t.build(wordList, argv[2]) == -1) {
     fprintf(stderr, "%s", t.getErrorLog().c_str());
-    fprintf(stderr, "cannot build index for %s\n",argv[1]);
+    fprintf(stderr, "cannot build index for %s\n", argv[1]);
     return -1;
   }
   fprintf(stderr, "%s", t.getResultLog().c_str());

--- a/txlist.cpp
+++ b/txlist.cpp
@@ -17,9 +17,10 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
 #include <fstream>
+#include <string>
 #include <vector>
+
 #include "tx.hpp"
 
 int main(int argc, char* argv[]){
@@ -30,8 +31,7 @@ int main(int argc, char* argv[]){
 
   tx_tool::tx t;
   if (t.read(argv[1]) == -1){
-    std::cerr << t.getErrorLog()
-	 << "cannot read index " << argv[1] << std::endl;
+    std::cerr << t.getErrorLog() << "cannot read index " << argv[1] << std::endl;
     return -1;
   }
   

--- a/txlist.cpp
+++ b/txlist.cpp
@@ -22,26 +22,24 @@
 #include <vector>
 #include "tx.hpp"
 
-using namespace std;
-
 int main(int argc, char* argv[]){
   if (argc != 2){
-    cerr << argv[1] << " index" << endl;
+    std::cerr << argv[1] << " index" << std::endl;
     return -1;
   }
 
   tx_tool::tx t;
   if (t.read(argv[1]) == -1){
-    cerr << t.getErrorLog()
-	 << "cannot read index " << argv[1] << endl;
+    std::cerr << t.getErrorLog()
+	 << "cannot read index " << argv[1] << std::endl;
     return -1;
   }
   
   tx_tool::uint keyNum = t.getKeyNum();
   for (tx_tool::uint i = 0; i < keyNum; ++i){
-    string ret;
+    std::string ret;
     t.reverseLookup(i, ret);
-    cout << ret << endl;
+    std::cout << ret << std::endl;
   }
 
   return 0;

--- a/txsearch.cpp
+++ b/txsearch.cpp
@@ -22,8 +22,6 @@
 #include <vector>
 #include "tx.hpp"
 
-using namespace std;
-
 int main(int argc, char* argv[]){
   if (argc != 2){
     fprintf(stderr,"%s index\n",argv[0]);
@@ -38,10 +36,10 @@ int main(int argc, char* argv[]){
   }
   fprintf(stderr,"%s", t.getResultLog().c_str());
 
-  string query;
+  std::string query;
   for (;;){
     putchar('>');
-    getline(cin,query);
+    getline(std::cin,query);
     if (query.size() == 0) break;
 
     printf("query:%s\n", query.c_str());
@@ -55,7 +53,7 @@ int main(int argc, char* argv[]){
       if (id == tx_tool::tx::NOTFOUND){
 	printf("not found\n");
       } else {
-	string retKey;
+	std::string retKey;
 	size_t retLen = t.reverseLookup(id, retKey);
 	printf("id:%u len:%lu lookup:%s\n", id, retLen, retKey.c_str());
       }
@@ -63,18 +61,18 @@ int main(int argc, char* argv[]){
 
     // expandSearch
     {
-      vector<string> ret;
+      std::vector<std::string> ret;
       const tx_tool::uint retNum = t.expandSearch(query.c_str(),query.size(), ret, 10);
       printf("expansionSearch %u\n", retNum);
-      for (vector<string>::const_iterator it = ret.begin(); it != ret.end(); it++){
+      for (std::vector<std::string>::const_iterator it = ret.begin(); it != ret.end(); it++){
 	printf("%s\n",it->c_str());
       }
     }
 
     // commonPrefixSearch
     {
-      vector<string> ret;
-      vector<tx_tool::uint> retID;
+      std::vector<std::string> ret;
+      std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t.commonPrefixSearch(query.c_str(),query.size(), ret, retID, 10);
       printf("commonPrefixSearch %u\n", retNum);
       for (size_t i = 0; i < ret.size(); i++){
@@ -84,8 +82,8 @@ int main(int argc, char* argv[]){
 
     // predictiveSearch
     {
-      vector<string> ret;
-      vector<tx_tool::uint> retID;
+      std::vector<std::string> ret;
+      std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t.predictiveSearch(query.c_str(),query.size(), ret, retID, 10);
       printf("predictiveSearch %u\n", retNum);
       for (size_t i = 0; i < ret.size(); i++){

--- a/txsearch.cpp
+++ b/txsearch.cpp
@@ -17,9 +17,10 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
 #include <fstream>
+#include <string>
 #include <vector>
+
 #include "tx.hpp"
 
 int main(int argc, char* argv[]){

--- a/txsearch_mmap.cpp
+++ b/txsearch_mmap.cpp
@@ -17,14 +17,16 @@
  *      software without specific prior written permission.
  */
 
-#include <string>
-#include <fstream>
-#include <vector>
+#include <fcntl.h>
+#include <stdio.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <stdio.h>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
 #include "tx.hpp"
 
 int main(int argc, char* argv[]){

--- a/txsearch_mmap.cpp
+++ b/txsearch_mmap.cpp
@@ -27,8 +27,6 @@
 #include <stdio.h>
 #include "tx.hpp"
 
-using namespace std;
-
 int main(int argc, char* argv[]){
   if (argc != 2){
     fprintf(stderr,"%s index\n",argv[0]);
@@ -65,10 +63,10 @@ int main(int argc, char* argv[]){
   }
   fprintf(stderr,"%s", t.getResultLog().c_str());
 
-  string query;
+  std::string query;
   for (;;){
     putchar('>');
-    getline(cin,query);
+    getline(std::cin,query);
     if (query.size() == 0) break;
 		
     // prefixSearch
@@ -85,18 +83,18 @@ int main(int argc, char* argv[]){
 
     // expandSearch
     {
-      vector<string> ret;
+      std::vector<std::string> ret;
       const tx_tool::uint retNum = t.expandSearch(query.c_str(),query.size(), ret, 10);
       printf("expansionSearch %u\n", retNum);
-      for (vector<string>::const_iterator it = ret.begin(); it != ret.end(); it++){
+      for (std::vector<std::string>::const_iterator it = ret.begin(); it != ret.end(); it++){
 	printf("%s\n",it->c_str());
       }
     }
 
     // commonPrefixSearch
     {
-      vector<string> ret;
-      vector<tx_tool::uint> retID;
+      std::vector<std::string> ret;
+      std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t.commonPrefixSearch(query.c_str(),query.size(), ret, retID, 10);
       printf("commonPrefixSearch %u\n", retNum);
       for (size_t i = 0; i < ret.size(); i++){
@@ -106,8 +104,8 @@ int main(int argc, char* argv[]){
 
     // predictiveSearch
     {
-      vector<string> ret;
-      vector<tx_tool::uint> retID;
+      std::vector<std::string> ret;
+      std::vector<tx_tool::uint> retID;
       const tx_tool::uint retNum = t.predictiveSearch(query.c_str(),query.size(), ret, retID, 10);
       printf("predictiveSearch %u\n", retNum);
       for (size_t i = 0; i < ret.size(); i++){


### PR DESCRIPTION
using namespace での名前空間の広い利用をやめました。
ついでに、ホワイトスペースまわりの修正と、インクルードガードの修正、マクロでの定数をconstに変更、あたりをやっています。
インクルードガードの修正に関しては、アンダースコア始まり、アンダースコア二連、どちらも識別子(マクロ名も識別子です)としてNGなのですが、一時のPFI風習に `__(ヘッダ名)__` を使う風習があって、古いコードがだいたいこのルールに違反していたりします。